### PR TITLE
Added device name and gateway name to alert list and modal

### DIFF
--- a/src/components/alarm_review.component.js
+++ b/src/components/alarm_review.component.js
@@ -519,11 +519,13 @@ class AlarmReviewComponent extends React.Component {
                       <Table.Row>
                         <Table.HeaderCell collapsing>ID/ADDRESS</Table.HeaderCell>
                         <Table.HeaderCell collapsing>RISK</Table.HeaderCell>
-                        <Table.HeaderCell >DESCRIPTION</Table.HeaderCell>
+                        <Table.HeaderCell>DESCRIPTION</Table.HeaderCell>
+                        <Table.HeaderCell collapsing>DEVICE NAME</Table.HeaderCell>
                         <Table.HeaderCell collapsing sorted={orderBy[0] === 'created_at' ? (orderBy[1] === 'ASC' ? 'ascending' : 'descending') : null} onClick={ () => this.handleSort('created_at')}>
                           DATE
                         </Table.HeaderCell>
                         <Table.HeaderCell>GATEWAY</Table.HeaderCell>
+                        <Table.HeaderCell collapsing>GATEWAY NAME</Table.HeaderCell>
                         <Table.HeaderCell>COLLECTOR</Table.HeaderCell>
                         <Table.HeaderCell collapsing>ACTIONS</Table.HeaderCell>
                       </Table.Row>
@@ -532,7 +534,7 @@ class AlarmReviewComponent extends React.Component {
                       <Table.Body>
                         {newAlerts && 
                         <Table.Row>
-                          <Table.Cell colSpan='6' verticalAlign='middle' style={{textAlign: 'center'}}>
+                          <Table.Cell colSpan='9' verticalAlign='middle' style={{textAlign: 'center'}}>
                             <Message info compact>
                               <Icon name='bell'/>
                               There're new alerts.&nbsp;&nbsp;<Button circular positive size='mini' icon='fas fa-sync' onClick={() => {this.updateRange('DAY');this.setState({newAlerts: false})}} content='Reload now'/>

--- a/src/components/alarm_review.component.js
+++ b/src/components/alarm_review.component.js
@@ -524,9 +524,9 @@ class AlarmReviewComponent extends React.Component {
                         <Table.HeaderCell collapsing sorted={orderBy[0] === 'created_at' ? (orderBy[1] === 'ASC' ? 'ascending' : 'descending') : null} onClick={ () => this.handleSort('created_at')}>
                           DATE
                         </Table.HeaderCell>
-                        <Table.HeaderCell>GATEWAY</Table.HeaderCell>
-                        <Table.HeaderCell collapsing>GATEWAY NAME</Table.HeaderCell>
-                        <Table.HeaderCell>COLLECTOR</Table.HeaderCell>
+                        <Table.HeaderCell collapsing>GATEWAY</Table.HeaderCell>
+                        <Table.HeaderCell>GATEWAY NAME</Table.HeaderCell>
+                        <Table.HeaderCell collapsing>COLLECTOR</Table.HeaderCell>
                         <Table.HeaderCell collapsing>ACTIONS</Table.HeaderCell>
                       </Table.Row>
                     </Table.Header>

--- a/src/components/alert.list.component.js
+++ b/src/components/alert.list.component.js
@@ -21,7 +21,7 @@ class AlertListComponent extends React.Component {
     if(!alerts || alerts.length === 0) {
       return (
         <Table.Row>
-          <Table.Cell colSpan='6'>
+          <Table.Cell colSpan='9'>
             <EmptyComponent emptyMessage="No alerts found" />
           </Table.Cell>
         </Table.Row>
@@ -41,8 +41,10 @@ class AlertListComponent extends React.Component {
                 <Table.Cell onClick={() => showAlertDetails(index)}>
                   {alert_types[alert.type].name}
                 </Table.Cell>
+                <Table.Cell onClick={() => showAlertDetails(index)}>{alert.parameters.dev_name}</Table.Cell>
                 <Table.Cell singleLine onClick={() => showAlertDetails(index)}>{<Moment format="YYYY-MM-DD HH:mm">{alert.created_at}</Moment>}</Table.Cell>
                 <Table.Cell onClick={() => showAlertDetails(index)} className="upper">{alert.parameters.gateway}</Table.Cell>
+                <Table.Cell onClick={() => showAlertDetails(index)}>{alert.parameters.gw_name}</Table.Cell>
                 <Table.Cell onClick={() => showAlertDetails(index)}>{alert.data_collector_name}</Table.Cell>
                 <Table.Cell className="td-actions">
                   {

--- a/src/components/alert/alert.details.table.icons.js
+++ b/src/components/alert/alert.details.table.icons.js
@@ -53,14 +53,15 @@ class AlertDetailTableIcon extends Component {
     }
 
     render(){
-        const {dev_eui, gateway, device_name, dev_addr} = this.props.parameters;
+        const {dev_eui, dev_name, gateway, gw_name, dev_addr} = this.props.parameters;
+
         return (
         <div className="div-container">
             <Table compact="very" basic="very">
             <Table.Header>
                 <Table.Row>
                     <Table.HeaderCell textAlign="center" className={dev_eui ? "" : "hide"}>
-                        {dev_eui && this.getDevicePopup(dev_eui, dev_addr, device_name, "device")}
+                        {dev_eui && this.getDevicePopup(dev_eui, dev_addr, dev_name, "device")}
                     </Table.HeaderCell>
                     <Table.HeaderCell textAlign="center" className={gateway && dev_eui ? "" : "hide"}>
                         <i className="fas fa-ellipsis-h icon-font-arrows-h" ></i>
@@ -73,13 +74,18 @@ class AlertDetailTableIcon extends Component {
             </Table.Header>
             <Table.Body>
                 <Table.Row>
-                <Table.Cell className={dev_eui ? "" : "hide"}>
-                    {this.getIconDescription(dev_eui)}
-                </Table.Cell>
-                <Table.Cell  className={gateway && dev_eui ? "" : "hide"}></Table.Cell>
-                <Table.Cell className={gateway ? "" : "hide"}>
-                    {this.getIconDescription(gateway)}
-                </Table.Cell>
+                    <Table.Cell className={dev_name || gw_name ? "" : "hide"} textAlign= "center">{dev_name? dev_name : ""}</Table.Cell>
+                    <Table.Cell  className={dev_name || gw_name ? "" : "hide"}></Table.Cell>
+                    <Table.Cell className={dev_name || gw_name ? "" : "hide"} textAlign= "center">{gw_name? gw_name : ""}</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                    <Table.Cell className={dev_eui ? "" : "hide"} textAlign= "center">
+                        {this.getIconDescription(dev_eui)}
+                    </Table.Cell>
+                    <Table.Cell  className={gateway && dev_eui ? "" : "hide"}></Table.Cell>
+                    <Table.Cell className={gateway ? "" : "hide"} textAlign= "center">
+                        {this.getIconDescription(gateway)}
+                    </Table.Cell>
                 </Table.Row>
             </Table.Body>
             </Table>

--- a/src/components/dashboard.component.js
+++ b/src/components/dashboard.component.js
@@ -425,11 +425,11 @@ class DashboardComponent extends React.Component {
                             <Table.HeaderCell collapsing>ID/ADDRESS</Table.HeaderCell>
                             <Table.HeaderCell collapsing>RISK</Table.HeaderCell>
                             <Table.HeaderCell>DESCRIPTION</Table.HeaderCell>
-                            <Table.HeaderCell>DEVICE NAME</Table.HeaderCell>
+                            <Table.HeaderCell collapsing>DEVICE NAME</Table.HeaderCell>
                             <Table.HeaderCell collapsing>DATE</Table.HeaderCell>
-                            <Table.HeaderCell>GATEWAY</Table.HeaderCell>
+                            <Table.HeaderCell collapsing>GATEWAY</Table.HeaderCell>
                             <Table.HeaderCell>GATEWAY NAME</Table.HeaderCell>
-                            <Table.HeaderCell>COLLECTOR</Table.HeaderCell>
+                            <Table.HeaderCell collapsing>COLLECTOR</Table.HeaderCell>
                             <Table.HeaderCell collapsing>ACTIONS</Table.HeaderCell>
                           </Table.Row>
                         </Table.Header>

--- a/src/components/dashboard.component.js
+++ b/src/components/dashboard.component.js
@@ -425,8 +425,10 @@ class DashboardComponent extends React.Component {
                             <Table.HeaderCell collapsing>ID/ADDRESS</Table.HeaderCell>
                             <Table.HeaderCell collapsing>RISK</Table.HeaderCell>
                             <Table.HeaderCell>DESCRIPTION</Table.HeaderCell>
+                            <Table.HeaderCell>DEVICE NAME</Table.HeaderCell>
                             <Table.HeaderCell collapsing>DATE</Table.HeaderCell>
                             <Table.HeaderCell>GATEWAY</Table.HeaderCell>
+                            <Table.HeaderCell>GATEWAY NAME</Table.HeaderCell>
                             <Table.HeaderCell>COLLECTOR</Table.HeaderCell>
                             <Table.HeaderCell collapsing>ACTIONS</Table.HeaderCell>
                           </Table.Row>

--- a/src/components/details.alert.modal.component.js
+++ b/src/components/details.alert.modal.component.js
@@ -127,11 +127,11 @@ class DetailsAlertModal extends Component {
         </Modal.Header>
         <Modal.Content>
           <Modal.Description>
+            <AlertDetailTableIcon parameters={this.props.alert.alert.parameters} />
             <p>{alert_type.description}</p>
             <div style={{marginBottom: 15 }}>
               <p style={{fontWeight: 'bolder', marginBottom: 3 }}>Source</p>
               Message collector <i>{alert.data_collector_name}</i>
-              <AlertDetailTableIcon parameters={this.props.alert.alert.parameters} />
             </div>
 
             <Accordion>

--- a/src/components/quarantine.component.js
+++ b/src/components/quarantine.component.js
@@ -372,9 +372,11 @@ class QuarantineComponent extends React.Component {
                           <Table.HeaderCell collapsing>ID/ADDRESS</Table.HeaderCell>
                           <Table.HeaderCell collapsing>RISK</Table.HeaderCell>
                           <Table.HeaderCell>DESCRIPTION</Table.HeaderCell>
+                          <Table.HeaderCell>DEVICE NAME</Table.HeaderCell>
                           <Table.HeaderCell collapsing>DATE</Table.HeaderCell>
                           <Table.HeaderCell collapsing>LAST CHECKED</Table.HeaderCell>
                           <Table.HeaderCell>GATEWAY</Table.HeaderCell>
+                          <Table.HeaderCell>GATEWAY NAME</Table.HeaderCell>
                           <Table.HeaderCell>COLLECTOR</Table.HeaderCell>
                           <Table.HeaderCell collapsing>ACTIONS</Table.HeaderCell>
                         </Table.Row>
@@ -393,9 +395,11 @@ class QuarantineComponent extends React.Component {
                                   </Label>
                                 </Table.Cell>
                                 <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert_type.name}</Table.Cell>
+                                <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert.parameters.dev_name}</Table.Cell>
                                 <Table.Cell singleLine onClick={() => this.showAlertDetails(index)}>{<Moment format="YYYY-MM-DD HH:mm">{item.since}</Moment>}</Table.Cell>
                                 <Table.Cell singleLine onClick={() => this.showAlertDetails(index)}>{<Moment format="YYYY-MM-DD HH:mm">{item.last_checked}</Moment>}</Table.Cell>
                                 <Table.Cell onClick={() => this.showAlertDetails(index)} className="upper">{item.alert.parameters.gateway}</Table.Cell>
+                                <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert.gw_name}</Table.Cell>
                                 <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.data_collector_name}</Table.Cell>
                                 <Table.Cell>
                                   <div className="td-actions">

--- a/src/components/quarantine.component.js
+++ b/src/components/quarantine.component.js
@@ -372,12 +372,12 @@ class QuarantineComponent extends React.Component {
                           <Table.HeaderCell collapsing>ID/ADDRESS</Table.HeaderCell>
                           <Table.HeaderCell collapsing>RISK</Table.HeaderCell>
                           <Table.HeaderCell>DESCRIPTION</Table.HeaderCell>
-                          <Table.HeaderCell>DEVICE NAME</Table.HeaderCell>
+                          <Table.HeaderCell collapsing>DEVICE NAME</Table.HeaderCell>
                           <Table.HeaderCell collapsing>DATE</Table.HeaderCell>
                           <Table.HeaderCell collapsing>LAST CHECKED</Table.HeaderCell>
-                          <Table.HeaderCell>GATEWAY</Table.HeaderCell>
+                          <Table.HeaderCell collapsing>GATEWAY</Table.HeaderCell>
                           <Table.HeaderCell>GATEWAY NAME</Table.HeaderCell>
-                          <Table.HeaderCell>COLLECTOR</Table.HeaderCell>
+                          <Table.HeaderCell collapsing>COLLECTOR</Table.HeaderCell>
                           <Table.HeaderCell collapsing>ACTIONS</Table.HeaderCell>
                         </Table.Row>
                       </Table.Header>
@@ -395,11 +395,11 @@ class QuarantineComponent extends React.Component {
                                   </Label>
                                 </Table.Cell>
                                 <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert_type.name}</Table.Cell>
-                                <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert.parameters.dev_name}</Table.Cell>
+                                <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert.parameters.dev_name }</Table.Cell>
                                 <Table.Cell singleLine onClick={() => this.showAlertDetails(index)}>{<Moment format="YYYY-MM-DD HH:mm">{item.since}</Moment>}</Table.Cell>
                                 <Table.Cell singleLine onClick={() => this.showAlertDetails(index)}>{<Moment format="YYYY-MM-DD HH:mm">{item.last_checked}</Moment>}</Table.Cell>
                                 <Table.Cell onClick={() => this.showAlertDetails(index)} className="upper">{item.alert.parameters.gateway}</Table.Cell>
-                                <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert.gw_name}</Table.Cell>
+                                <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.alert.parameters.gw_name}</Table.Cell>
                                 <Table.Cell onClick={() => this.showAlertDetails(index)}>{item.data_collector_name}</Table.Cell>
                                 <Table.Cell>
                                   <div className="td-actions">


### PR DESCRIPTION
Added the device name and gateway name to the alert list and alert details modal. The merge of this PR closes #2.

**List**
- Dashboard list
![List](https://user-images.githubusercontent.com/27182260/83178577-181ad780-a0f7-11ea-9734-2ea473387e3b.png)
- Alerts tab list
![image](https://user-images.githubusercontent.com/27182260/83179780-dd19a380-a0f8-11ea-8949-3574d85860fd.png)


**Modal**
- with both device name and gateway name
![Modal with both device name and gateway name](https://user-images.githubusercontent.com/27182260/83178612-279a2080-a0f7-11ea-823e-5f6a0b9c581c.png)

- only device name
![Selección_096](https://user-images.githubusercontent.com/27182260/83178804-6fb94300-a0f7-11ea-9b3d-04b8a25ba528.png)

- only gateway name
![Selección_097](https://user-images.githubusercontent.com/27182260/83178836-7a73d800-a0f7-11ea-9398-1c8237907c07.png)

- without names
![Selección_098](https://user-images.githubusercontent.com/27182260/83178853-8364a980-a0f7-11ea-9d1d-449c21b398cb.png)

