### PR TITLE
Add tls fields and change server ip validation to ip or hostname

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "file-saver": "^2.0.2",
     "http-status-codes": "^1.4.0",
     "interweave": "^11.1.0",
+    "is-valid-hostname": "^1.0.0",
     "jwt-decode": "^2.2.0",
     "leaflet": "^1.7.1",
     "lodash": "^4.17.20",

--- a/src/components/data_collectors.new.component.js
+++ b/src/components/data_collectors.new.component.js
@@ -34,6 +34,9 @@ class DataCollectorsNewComponent extends React.Component {
         name: "",
         description: "",
         ip: "",
+        ca_cert: null,
+        client_cert: null,
+        client_key: null,
         port: "",
         user: "",
         password: "",
@@ -163,6 +166,9 @@ class DataCollectorsNewComponent extends React.Component {
         name: "",
         description: "",
         ip: "",
+        ca_cert: null,
+        client_cert: null,
+        client_key: null,
         port: "",
         user: "",
         password: "",
@@ -239,6 +245,9 @@ class DataCollectorsNewComponent extends React.Component {
             data_collector_type_id,
             policy_id,
             gateway_id,
+            ca_cert,
+            client_cert,
+            client_key
           } = response.data;
           const dataCollector = {
             name,
@@ -252,6 +261,9 @@ class DataCollectorsNewComponent extends React.Component {
             data_collector_type_id,
             policy_id,
             gateway_id,
+            ca_cert,
+            client_cert,
+            client_key
           };
           this.setState({ dataCollector, dataCollectorId, typeForm: "Edit" });
           this.setState({ isLoading: false });
@@ -399,6 +411,9 @@ class DataCollectorsNewComponent extends React.Component {
       data_collector_type_id,
       policy_id,
       gateway_id,
+      ca_cert,
+      client_cert,
+      client_key
     } = this.state.dataCollector;
     const {
       newTopic,
@@ -423,7 +438,7 @@ class DataCollectorsNewComponent extends React.Component {
       name.length <= 120 &&
       (!description || description.length <= 1000) &&
       (dataCollectorTypeCode === "ttn_collector" ||
-        (Validation.isValidIp(ip) && Validation.isValidPort(port))) &&
+        ((Validation.isValidIp(ip) || Validation.isValidHostname(ip)) && Validation.isValidPort(port))) &&
       data_collector_type_id &&
       policy_id &&
       ((dataCollectorTypeCode !== "ttn_collector" &&
@@ -522,10 +537,10 @@ class DataCollectorsNewComponent extends React.Component {
                           name="ip"
                           value={ip}
                           onChange={this.handleChange}
-                          error={!!ip && !Validation.isValidIp(ip)}
+                          error={!!ip && !(Validation.isValidIp(ip) || Validation.isValidHostname(ip))}
                         >
                           <input />
-                          <label>Server IP Address</label>
+                          <label>Server IP Address/Hostname</label>
                         </Form.Input>
                       </Form.Field>
                       <Form.Field required>
@@ -661,6 +676,19 @@ class DataCollectorsNewComponent extends React.Component {
                           </div>
                         )}
                       </Form.Group>
+                      {ssl &&
+                        <Form.Group>
+                          <Form.Field>
+                            <Form.TextArea name='ca_cert' value={ca_cert || ""} onChange={this.handleChange} label="CA Certificate" />
+                          </Form.Field>
+                          <Form.Field>
+                            <Form.TextArea name='client_cert' value={client_cert || ""} onChange={this.handleChange} label="Client Certificate" />
+                          </Form.Field>
+                          <Form.Field>
+                            <Form.TextArea name='client_key' value={client_key || ""} onChange={this.handleChange} label="Client Private Key" />
+                          </Form.Field>
+                        </Form.Group>
+                      }
                     </div>
                   )}
                   {

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -1,7 +1,12 @@
+import isValidHostname from 'is-valid-hostname';
 const Validation = {
   isValidUsername: (username) => {
     const regex = new RegExp("^[a-z0-9-_.]{3,32}$");
     return regex.test(username);
+  },
+
+  isValidHostname: (text) => {
+    return isValidHostname(text);
   },
 
   hasLength: (text, length) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6676,6 +6676,11 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-valid-hostname@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-valid-hostname/-/is-valid-hostname-1.0.0.tgz#175b21f18eedf25e0f2860b6b8c4e3afd145fcfb"
+  integrity sha512-oTlvlRUnxrEwFQoRMvEe2UOB5/++ou2dcMVMnjAixgZsZ8Rbo8cH4dYbB0fxcA9q6WsJxnYjwkzOwKiDbIIOCw==
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"


### PR DESCRIPTION
Add tls authentication fields for data collectors and validate the IP  also as hostname. With AWS IoT, the MQTT server's hostname can resolve to multiple IP addresses.

## Changes
- add ca_cert, client_cert and client_key fields
- Validate ip to be a valid IP or a hostname

## Related issues
https://github.com/Argeniss-Software/rolaguard/issues/10