### PR TITLE
Fix hide pagination controls for empty responses

### DIFF
--- a/src/components/alarm_review.component.js
+++ b/src/components/alarm_review.component.js
@@ -995,7 +995,7 @@ class AlarmReviewComponent extends React.Component {
                         style={{ marginBottom: 20 }}
                       />
                     )}
-                    {!this.state.isLoading && (
+                    {!this.state.isLoading && alertsCount!=null && alertsCount>0 && (
                       <Pagination
                         className=""
                         activePage={activePage}
@@ -1003,7 +1003,7 @@ class AlarmReviewComponent extends React.Component {
                         totalPages={totalPages}
                       />
                     )}
-                    {!this.state.isLoading && (
+                    {!this.state.isLoading && alertsCount!=null && alertsCount>0 && (
                       <Menu compact>
                         <Dropdown
                           className=""

--- a/src/components/inventory/inventory.component.js
+++ b/src/components/inventory/inventory.component.js
@@ -1018,7 +1018,7 @@ class InventoryReviewComponent extends React.Component {
                           style={{ marginBottom: 20, height: "320px" }}
                         />
                       )}
-                      {!isLoading && (
+                      {!isLoading && this.state.assetsCount!=null && this.state.assetsCount > 0 && (
                         <Grid className="segment centered">
                           <Pagination
                             className=""

--- a/src/components/resource-usage/resource-usage.component.js
+++ b/src/components/resource-usage/resource-usage.component.js
@@ -333,7 +333,7 @@ const ResourceUsageComponent = (props) => {
                     style={{ marginBottom: 20 }}
                   />
                 )}
-                {!resourceUsageStore.model.isLoading && (
+                {!resourceUsageStore.model.isLoading && resourceUsageStore.model.totalList!=null && resourceUsageStore.model.totalList>0 && (
                     <Grid className="segment centered">
                       <Pagination
                         className=""


### PR DESCRIPTION
## Changes proposal:
- Hides pagination controls when the response is empty. Showing them with no elements can result in unwanted behavior.